### PR TITLE
Migrate to Capacitor 3

### DIFF
--- a/JoinfluxCapacitorFirebaseDynamicLinks.podspec
+++ b/JoinfluxCapacitorFirebaseDynamicLinks.podspec
@@ -1,14 +1,14 @@
 
   Pod::Spec.new do |s|
     s.name = 'JoinfluxCapacitorFirebaseDynamicLinks'
-    s.version = '0.0.4'
+    s.version = '0.1'
     s.summary = 'Capacitor Plugin for Firebase Dynamic Links'
     s.license = 'MIT'
     s.homepage = 'https://github.com/joinflux/capacitor-firebase-dynamic-links.git'
     s.author = ''
     s.source = { :git => 'https://github.com/joinflux/capacitor-firebase-dynamic-links.git', :tag => s.version.to_s }
     s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
-    s.ios.deployment_target  = '11.0'
+    s.ios.deployment_target  = '12.0'
     s.dependency 'Capacitor'
     s.dependency 'Firebase/Analytics'
     s.dependency 'Firebase/DynamicLinks'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,7 +43,6 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.firebase:firebase-dynamic-links:19.0.0'
 }
-

--- a/android/src/main/java/com/joinflux/flux/capacitorfirebasedynamiclinks/CapacitorFirebaseDynamicLinks.java
+++ b/android/src/main/java/com/joinflux/flux/capacitorfirebasedynamiclinks/CapacitorFirebaseDynamicLinks.java
@@ -3,7 +3,7 @@ package com.joinflux.flux.capacitorfirebasedynamiclinks;
 import android.content.Intent;
 import android.net.Uri;
 import com.getcapacitor.JSObject;
-import com.getcapacitor.NativePlugin;
+import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
@@ -18,7 +18,7 @@ import androidx.annotation.NonNull;
 
 import static android.content.ContentValues.TAG;
 
-@NativePlugin()
+@CapacitorPlugin()
 public class CapacitorFirebaseDynamicLinks extends Plugin {
 
     private static final String EVENT_DEEP_LINK = "deepLinkOpen";

--- a/ios/Plugin.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/Plugin.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ios/Plugin.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/Plugin.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -13,8 +13,8 @@ public class CapacitorFirebaseDynamicLinks: CAPPlugin {
             FirebaseApp.configure()
         }
 
-        NotificationCenter.default.addObserver(self, selector: #selector(self.handleUrlOpened(notification:)), name: Notification.Name(CAPNotifications.URLOpen.name()), object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(self.handleUniversalLink(notification:)), name: Notification.Name(CAPNotifications.UniversalLinkOpen.name()), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.handleUrlOpened(notification:)), name: Notification.Name.capacitorOpenURL, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.handleUniversalLink(notification:)), name: Notification.Name.capacitorOpenUniversalLink, object: nil)
     }
     
     

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 def capacitor_pods
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Capacitor (2.4.6):
+  - Capacitor (3.1.2):
     - CapacitorCordova
-  - CapacitorCordova (2.4.6)
+  - CapacitorCordova (3.1.2)
   - Firebase/Analytics (6.7.0):
     - Firebase/Core
   - Firebase/Core (6.7.0):
@@ -103,8 +103,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@capacitor/ios"
 
 SPEC CHECKSUMS:
-  Capacitor: 0f131577d41c082931f00cc080e2289d503465c8
-  CapacitorCordova: 3375b39b5ebca770ac7869f85e4dea32a642c9e0
+  Capacitor: 9d06cf7a97c4752037907979baade2f79f2800fa
+  CapacitorCordova: b8e7144f5dad047965035dbed9c9855b1f0f64e8
   Firebase: 291d7b0a7b393f252358083b5d224884126fa46d
   FirebaseAnalytics: 843c7f64a8f9c79f0d03281197ebe7bb1d58d477
   FirebaseAnalyticsInterop: d48b6ab67bcf016a05e55b71fc39c61c0cb6b7f3
@@ -119,6 +119,6 @@ SPEC CHECKSUMS:
   GoogleUtilities: e7dc37039b19df7fe543479d3e4a02ac8d11bb69
   nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
 
-PODFILE CHECKSUM: c044077c776249fcb0be61eaea771d9c1c95f26d
+PODFILE CHECKSUM: 646dcd6a64a46a41c8c2e4510b58980e4ec95c77
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.10.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,38 +1,38 @@
 {
   "name": "@joinflux/capacitor-firebase-dynamic-links",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@capacitor/android": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-2.4.6.tgz",
-      "integrity": "sha512-SBXO0eVtkssnq1gfs6n/8vJLJXPjzqbIblhPetMiR0Myvjt9eqB7v5HbQ4t1EW0+jV46UGyFV6CPCrZeKPtvXg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-3.1.2.tgz",
+      "integrity": "sha512-WF2E2jWxO3EBl8Y3aTAa8PHwMZGiAl9pdqvJaEUUhbbovXe0UxAuG4n0mfci4ZI6dD8gannQ2peoZ74vJ0Gr3Q==",
       "dev": true
     },
     "@capacitor/core": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-2.4.6.tgz",
-      "integrity": "sha512-3KLSMorCELA5RNRXwHOGlRGuxXaxCEYHC29wOUxObicI2mf14hbMJWylt4QBzNmSqh3/ha7u4/CAZMoJUQR/QA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-3.1.2.tgz",
+      "integrity": "sha512-cMqDY4JTNtyonqVPYxHqbmN3M3jlEBnQxecptlR+6yk/ZuhUwOJTHT1ActXRLyrQ8XIc74+9Yd37fwjWckSwFg==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "^2.1.0"
       }
     },
     "@capacitor/ios": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-2.4.6.tgz",
-      "integrity": "sha512-/IMmgVUgQgMm1Yv5CaWhZ9UTkVh5GFDX1vFZOB0bMu5v5jkolO/9SLyjbqogDNE2EIl9GuH6RSqZaOh2Xu2Ebg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-3.1.2.tgz",
+      "integrity": "sha512-y6wnTLK0I/ckTuofzeRkXK0OPw6vAKOj0I6QXwg2DxDdtiHmed6qP/G8cvwNBiFhZE9xfXAulxRYP8D76TPtNQ==",
       "dev": true
     },
     "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joinflux/capacitor-firebase-dynamic-links",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "Capacitor Plugin for Firebase Dynamic Links",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
@@ -13,7 +13,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@capacitor/core": "latest"
+    "@capacitor/core": "^3.0.0"
   },
   "devDependencies": {
     "@capacitor/android": "latest",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,16 +1,13 @@
 import { PluginListenerHandle } from "@capacitor/core";
 
-declare module "@capacitor/core" {
-  interface PluginRegistry {
-    CapacitorFirebaseDynamicLinks: CapacitorFirebaseDynamicLinksPlugin;
-  }
-}
-
 export interface CapacitorFirebaseDynamicLinksPlugin {
-  addListener(eventName: 'deepLinkOpen', listenerFunc: (data: DeepLinkOpen) => void): PluginListenerHandle;
+  addListener(
+    eventName: "deepLinkOpen",
+    listenerFunc: (data: DeepLinkOpen) => void
+  ): PluginListenerHandle;
 }
 
 export interface DeepLinkOpen {
-  slug: string
-  query: string
+  slug: string;
+  query: string;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -6,10 +6,7 @@ export class CapacitorFirebaseDynamicLinksWeb
   implements CapacitorFirebaseDynamicLinksPlugin
 {
   constructor() {
-    super({
-      name: "CapacitorFirebaseDynamicLinks",
-      platforms: ["web"],
-    });
+    super();
   }
 }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,18 +1,23 @@
-import { WebPlugin } from '@capacitor/core';
-import { CapacitorFirebaseDynamicLinksPlugin } from './definitions';
+import { registerPlugin, WebPlugin } from "@capacitor/core";
+import { CapacitorFirebaseDynamicLinksPlugin } from "./definitions";
 
-export class CapacitorFirebaseDynamicLinksWeb extends WebPlugin implements CapacitorFirebaseDynamicLinksPlugin {
+export class CapacitorFirebaseDynamicLinksWeb
+  extends WebPlugin
+  implements CapacitorFirebaseDynamicLinksPlugin
+{
   constructor() {
     super({
-      name: 'CapacitorFirebaseDynamicLinks',
-      platforms: ['web']
+      name: "CapacitorFirebaseDynamicLinks",
+      platforms: ["web"],
     });
   }
 }
 
-const CapacitorFirebaseDynamicLinks = new CapacitorFirebaseDynamicLinksWeb();
-
+const CapacitorFirebaseDynamicLinks =
+  registerPlugin<CapacitorFirebaseDynamicLinksWeb>(
+    "CapacitorFirebaseDynamicLinks",
+    {
+      web: () => new CapacitorFirebaseDynamicLinksWeb(),
+    }
+  );
 export { CapacitorFirebaseDynamicLinks };
-
-import { registerWebPlugin } from '@capacitor/core';
-registerWebPlugin(CapacitorFirebaseDynamicLinks);


### PR DESCRIPTION
This PR updates Capacitor from version 2 to version 3, and updates the plugin implementation and configuration to work with Capacitor 3.

* changed iOS deployment target from iOS 11 to iOS 12
* change version from `0.0.4` to `0.1`
* update Android annotations in plugin implementation
* update web implementation for new registration process