### PR TITLE
Allow a configurable universal links notification name for IOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,71 @@ Nothing more needed
 
 None
 
+## Configuration
+
+| Name                     | Type     | Description                                                                                                                   |
+| ------------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| universalLinksNotificationName | string | (IOS only) Overrides the default notification name used by Capacitor. Override this if you have other plugins (e.g. Apps Flyer) that also use deep links. See more info below |
+
+Provide configuration in root `capacitor.config.json`
+
+```json
+{
+  "plugins": {
+    "FirebaseDynamicLinks": {
+      "universalLinksNotificationName": "firebaseOpenUniversalLink"
+    }
+  }
+}
+```
+
+or in `capacitor.config.ts`
+
+```ts
+const config: CapacitorConfig = {
+  plugins: {
+    FirebaseDynamicLinks: {
+      universalLinksNotificationName: 'firebaseOpenUniversalLink',
+    },
+  },
+};
+```
+
+### (IOS only) Additional set up for `universalLinksNotificationName`
+
+If you use this configuration, you need to intercept Firebase Dynamic links in your `AppDelegate.swift` file. For example:
+
+``` swift
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    ...omitted for brevity
+
+    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+        // To get Firebase dynamic links to play along nicely with Apps Flyer,
+        // we intercept them and use a custom notification name
+        let url = userActivity.webpageURL?.absoluteString
+        if (url != nil && isFirebaseDynamicLink(url: url!)) {
+            // The notification name has to match what you've specified in your Capacitor config
+            NotificationCenter.default.post(name: Notification.Name("firebaseOpenUniversalLink"), object: [
+                "url": userActivity.webpageURL
+            ])
+            return true
+        }
+
+        // Called when the app was launched with an activity, including Universal Links.
+        // Feel free to add additional processing here, but if you want the App API to support
+        // tracking app url opens, make sure to keep this call
+        return ApplicationDelegateProxy.shared.application(application, continue: userActivity, restorationHandler: restorationHandler)
+    }
+
+    func isFirebaseDynamicLink(url: String) -> Bool {
+        return url.hasPrefix("https://your-firebase-links.page.link")
+    }
+}
+```
+
 ## Methods
 
 ### AddListener

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ None
 
 | Name                     | Type     | Description                                                                                                                   |
 | ------------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| universalLinksNotificationName | string | (IOS only) Overrides the default notification name used by Capacitor. Override this if you have other plugins (e.g. Apps Flyer) that also use deep links. See more info below |
+| universalLinksNotificationName | string | (IOS only) Overrides the default notification name used by Capacitor. Configure this if you have other plugins (e.g. Apps Flyer) that also use deep links. See more info below |
 
 Provide configuration in root `capacitor.config.json`
 

--- a/ios/Plugin/FirebaseDynamicLinksPlugin.swift
+++ b/ios/Plugin/FirebaseDynamicLinksPlugin.swift
@@ -5,10 +5,6 @@ import FirebaseDynamicLinks
 
 typealias JSObject = [String:Any]
 
-extension Notification.Name {
-    public static let firebaseDynamicLink = Notification.Name(rawValue: "FirebaseDynamicLink")
-}
-
 @objc(CapacitorFirebaseDynamicLinks)
 public class CapacitorFirebaseDynamicLinks: CAPPlugin {
 
@@ -17,8 +13,16 @@ public class CapacitorFirebaseDynamicLinks: CAPPlugin {
             FirebaseApp.configure()
         }
 
+        var universalLinkNotificationName = Notification.Name.capacitorOpenUniversalLink
+
+        let config = self.getConfig()
+        let universalLinkConfig = config.getString("universalLinksNotificationName")
+        if (universalLinkConfig != nil) {
+            universalLinkNotificationName = Notification.Name(universalLinkConfig!)
+        }
+
         NotificationCenter.default.addObserver(self, selector: #selector(self.handleUrlOpened(notification:)), name: Notification.Name.capacitorOpenURL, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(self.handleUniversalLink(notification:)), name: Notification.Name.firebaseDynamicLink, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.handleUniversalLink(notification:)), name: universalLinkNotificationName, object: nil)
     }
 
     @objc func handleUrlOpened(notification: NSNotification) {

--- a/ios/Plugin/FirebaseDynamicLinksPlugin.swift
+++ b/ios/Plugin/FirebaseDynamicLinksPlugin.swift
@@ -5,18 +5,22 @@ import FirebaseDynamicLinks
 
 typealias JSObject = [String:Any]
 
+extension Notification.Name {
+    public static let firebaseDynamicLink = Notification.Name(rawValue: "FirebaseDynamicLink")
+}
+
 @objc(CapacitorFirebaseDynamicLinks)
 public class CapacitorFirebaseDynamicLinks: CAPPlugin {
-    
+
     public override func load() {
         if (FirebaseApp.app() == nil) {
             FirebaseApp.configure()
         }
 
         NotificationCenter.default.addObserver(self, selector: #selector(self.handleUrlOpened(notification:)), name: Notification.Name.capacitorOpenURL, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(self.handleUniversalLink(notification:)), name: Notification.Name.capacitorOpenUniversalLink, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.handleUniversalLink(notification:)), name: Notification.Name.firebaseDynamicLink, object: nil)
     }
-    
+
     @objc func handleUrlOpened(notification: NSNotification) {
         guard let object = notification.object as? [String:Any?] else {
             return
@@ -25,12 +29,12 @@ public class CapacitorFirebaseDynamicLinks: CAPPlugin {
         guard let dynamicLink = DynamicLinks.dynamicLinks().dynamicLink(fromCustomSchemeURL: object["url"] as! URL) else {
             return
         }
-            
+
         let params = dynamicLink.url?.query ?? ""
         let path = dynamicLink.url?.path ?? ""
         self.sendNotification(path: path, params: params)
     }
-    
+
     @objc func handleUniversalLink(notification: NSNotification) {
         guard let object = notification.object as? [String:Any?] else {
             return
@@ -42,7 +46,7 @@ public class CapacitorFirebaseDynamicLinks: CAPPlugin {
             self.sendNotification(path: path, params: params)
         }
     }
-    
+
     func sendNotification(path: String, params: String) {
         let data = ["slug": path, "query": params ]
         self.notifyListeners("deepLinkOpen", data: data, retainUntilConsumed: true)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joinflux/capacitor-firebase-dynamic-links",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Capacitor Plugin for Firebase Dynamic Links",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
This PR allows the configuration of the Notification Name for IOS specifically for Firebase dynamic links so that it doesn't clash with other deep link plugins

I've only tested this plugin co-existing with the [Apps Flyer plugin](https://github.com/AppsFlyerSDK/appsflyer-capacitor-plugin) not with other deep link plugins

For Android, even with no changes, it seems to "just work"